### PR TITLE
node-sass依赖更换为sass, 新增@remax/plugin-linaria 插件(用于支持css in js)

### DIFF
--- a/packages/linaria/LICENSE
+++ b/packages/linaria/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 - present Weizhu <yesmeck@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/linaria/README.md
+++ b/packages/linaria/README.md
@@ -1,4 +1,4 @@
-# @remax/plugin-stylus
+# @remax/plugin-linaria
 
 增加 linaria css in js支持。
 

--- a/packages/linaria/README.md
+++ b/packages/linaria/README.md
@@ -1,0 +1,56 @@
+# @remax/plugin-stylus
+
+增加 linaria css in js支持。
+
+## 安装
+
+```bash
+$ npm install @remax/plugin-linaria linaria @linaria/shaker @linaria/babel-preset --save
+```
+
+```bash
+$ yarn add @remax/plugin-linaria linaria @linaria/shaker @linaria/babel-preset
+```
+
+## 使用
+
+```js
+const linaria = require('@remax/plugin-linaria');
+
+module.exports = {
+    plugins: [linaria()],
+};
+```
+
+## 根目录新增 babel.config.js 并配置
+
+```js
+module.exports = {
+    presets: [
+        ['remax', {
+            framework: 'react',
+            ts: true
+        }],
+        '@linaria' // 添加到 babel-preset
+    ]
+}
+```
+
+## 根目录新增 linaria.config.js 并配置
+```js
+module.exports = {
+    rules: [
+        {
+            action: require('@linaria/shaker').default,
+        },
+        {
+            test: /node_modules[\/\\](?!remax)/,
+            action: "ignore"
+        }
+    ]
+}
+```
+
+## LICENSE
+
+[MIT](LICENSE)

--- a/packages/linaria/index.js
+++ b/packages/linaria/index.js
@@ -1,5 +1,4 @@
 const linaria = () => {
-    console.log(require.resolve('@linaria/webpack-loader'));
     return {
         configWebpack({config}) {
             config.module

--- a/packages/linaria/index.js
+++ b/packages/linaria/index.js
@@ -1,0 +1,16 @@
+const linaria = () => {
+    console.log(require.resolve('@linaria/webpack-loader'));
+    return {
+        configWebpack({config}) {
+            config.module
+                .rule('js')
+                .use('linarial-loader')
+                .loader(require.resolve('@linaria/webpack-loader'))
+                .options({
+                    sourceMap: process.env.NODE_ENV !== 'production',
+                })
+        }
+    };
+};
+
+module.exports = linaria;

--- a/packages/linaria/package.json
+++ b/packages/linaria/package.json
@@ -11,7 +11,7 @@
     "miniprogram",
     "remax"
   ],
-  "author": "Watsonhaw <wangjue5577w@gmail.com>",
+  "author": "Watsonhaw <wangjue5577@gmail.com>",
   "license": "MIT",
   "dependencies": {
     "@babel/core": "^7.15.0",

--- a/packages/linaria/package.json
+++ b/packages/linaria/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@remax/plugin-linaria",
+  "version": "1.0.0",
+  "description": "Remax linaria 插件",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "wechat",
+    "miniprogram",
+    "remax"
+  ],
+  "author": "Watsonhaw <wangjue5577w@gmail.com>",
+  "license": "MIT",
+  "dependencies": {
+    "@babel/core": "^7.15.0",
+    "@linaria/shaker": "^3.0.0-beta.7",
+    "@linaria/webpack-loader": "^3.0.0-beta.7"
+  },
+  "peerDependencies": {
+    "remax": "> 2.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/sass/package.json
+++ b/packages/sass/package.json
@@ -17,7 +17,7 @@
     "remax": "> 2.0.0"
   },
   "dependencies": {
-    "node-sass": "^4.14.0",
+    "sass": "^1.37.5",
     "sass-loader": "^8.0.2"
   },
   "publishConfig": {

--- a/packages/sass/package.json
+++ b/packages/sass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remax/plugin-sass",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Remax Sass 插件",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
[可以用sass代替node-sass](https://github.com/remaxjs/plugins/issues/2)
由于node-sass安装不稳定故换成安装更快的sass模块

新增@remax/plugin-linaria 插件，用于支持css in js方式