### PR TITLE
fix: 修复 wx-share apiList 传参问题

### DIFF
--- a/packages/wx-shake/README.md
+++ b/packages/wx-shake/README.md
@@ -8,10 +8,13 @@
 
 ## 安装
 
+> 注意 string-replace-loader 版本需要是 2.3.0 请勿使用3以上的版本，3以上版本是适配 webpack5 ,Remax 2.0 版本暂不适用
+
 ```bash
-$ npm install @remax/plugin-wx-shake --save
-或者
-$ yarn add @remax/plugin-wx-shake -D
+$ npm install @remax/plugin-wx-shake string-replace-loader@2.3.0 --save
+or
+$ yarn add @remax/plugin-wx-shake  string-replace-loader@2.3.0 -D
+
 ```
 
 ## 使用
@@ -57,7 +60,7 @@ const WxShake = require('@remax/plugin-wx-shake');
 const apiList = ['getWeRunData']
 
 module.exports = {
-    plugins: [WxShake({apiList})],
+    plugins: [WxShake(apiList)],
 };
 ```
 

--- a/packages/wx-shake/index.js
+++ b/packages/wx-shake/index.js
@@ -13,7 +13,14 @@ const defaultShakeApiList = [
     'addPhoneCalender',
     'saveFileToDisk',
 ]
-const WxShake = ({apiList}) => {
+
+const WxShake = (apiList = null) => {
+    let multipleList = []
+    if (apiList) {
+        multipleList = apiList
+    } else {
+        multipleList = defaultShakeApiList
+    }
     return {
         configWebpack({config}) {
             config.module
@@ -22,7 +29,7 @@ const WxShake = ({apiList}) => {
                 .use('string-replace-loader')
                 .loader('string-replace-loader')
                 .options({
-                    multiple: apiList !== undefined ? apiList : defaultShakeApiList
+                    multiple: multipleList
                         .map((search, index) => {
                             const replace = `REPLACEMENT${index}`; // or use random string
                             return [

--- a/packages/wx-shake/package.json
+++ b/packages/wx-shake/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remax/plugin-wx-shake",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "移除remax中没有使用过的wx接口",
   "main": "index.js",
   "scripts": {

--- a/packages/wx-shake/package.json
+++ b/packages/wx-shake/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remax/plugin-wx-shake",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "移除remax中没有使用过的wx接口",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
之前的插件有bug ，configWebpack 中不能使用三元表达式，需要先判定需要的列表参数后再传值。
string-replace-loader 属于第三方插件，需要用户安装后方可使用。另外我修改了传参的方式，使用单参数而不是对象的形式。
